### PR TITLE
feat: add default parser plugins to support common syntax out of the box

### DIFF
--- a/src/__tests__/defaultParserPlugins.test.js
+++ b/src/__tests__/defaultParserPlugins.test.js
@@ -1,0 +1,21 @@
+const defaultParserPlugins = require('../utils/defaultParserPlugins')
+
+test('must merge the plugins', () => {
+    expect(defaultParserPlugins(['foo'])).toEqual(['typescript', 'classProperties', 'foo'])
+})
+
+test('must dedupe the plugins', () => {
+    expect(defaultParserPlugins(['foo', 'typescript'])).toEqual(['typescript', 'classProperties', 'foo'])
+})
+
+test('must handle undefined plugins', () => {
+    expect(defaultParserPlugins(undefined)).toEqual(['typescript', 'classProperties'])
+})
+
+test('must handle null plugins', () => {
+    expect(defaultParserPlugins(null)).toEqual(['typescript', 'classProperties'])
+})
+
+test('must handle empty plugins', () => {
+    expect(defaultParserPlugins([])).toEqual(['typescript', 'classProperties'])
+})

--- a/src/utils/defaultParserPlugins.js
+++ b/src/utils/defaultParserPlugins.js
@@ -1,0 +1,6 @@
+
+const DEFAULT_PARSER_PLUGINS = ['typescript', 'classProperties'];
+
+module.exports = plugins => [
+    ...new Set([...DEFAULT_PARSER_PLUGINS, ...(plugins || [])])
+];

--- a/src/utils/extractSrcDeps.js
+++ b/src/utils/extractSrcDeps.js
@@ -2,6 +2,7 @@ const glob = require("glob");
 const fs = require("fs");
 const get = require("lodash.get");
 const parse = require("./parse");
+const defaultParserPlugins = require('./defaultParserPlugins');
 
 const isIgnoredPath = ({ path, instance, adioRc }) => {
     let dirs = get(instance, "config.ignoreDirs") || [];
@@ -43,7 +44,11 @@ module.exports = ({ dir, instance, adioRc }) => {
             src,
             config: {
                 parser: {
-                    ...get(adioRc, "parser", get(instance, "config.parser", {}))
+                    ...get(adioRc, "parser", get(instance, "config.parser", {})),
+                    // include commonly needed plugins
+                    plugins: defaultParserPlugins(
+                        get(adioRc, "parser.plugins", get(instance, "config.parser.plugins", []))
+                    )
                 },
                 traverse: get(adioRc, "traverse", get(instance, "config.traverse"))
             }


### PR DESCRIPTION
## Related Issue
#9 

## Your solution
Adds `typescript` and `classProperties` as default plugins passed to the `@babel/parser`. This enables `adio` to be able to handle some common syntax, like TypeScript syntax, out of the box.

## How Has This Been Tested?
I added some unit tests to test the added functionality. I then tested it in a local project via `link` and all seems to be working.
